### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This project demonstrates how to generate a zero-knowledge (zk) proof of a stora
 1. Clone the Repository
     - Start by cloning this repository to your local machine.
   ```bash
-    git clone https://github.com/aerius-labs/sp1-ethereum-storage-proofs.git
+    git clone https://github.com/aerius-labs/sp1-ethereum-storage-proofs
   ```
 
 2. Switch to Rust Nightly


### PR DESCRIPTION
without .git is correct.

have a good day!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README to use the repository URL without the .git suffix, aligning with common GitHub formatting. This clarifies copying/sharing the repo link from the README and reduces confusion when navigating on the web. No code, dependency, or runtime behavior changes. Existing workflows and integrations remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->